### PR TITLE
Fix tar-up-release.sh

### DIFF
--- a/tar-up-release.sh
+++ b/tar-up-release.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-VERSION=`$1 --version | cut -f 3 -d ' '`
+VERSION=`$1 --version | cut -f 3 -d ' ' | head -n 1`
 tar -czf dist/smudge-$VERSION-$2.tgz dist/release


### PR DESCRIPTION
The version output from Smudge became multi-line recently.

Hooray for open source!