### PR TITLE
Fix `make release` and update README with some stack info.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ SMUDGE_EXE=smudge
 PLATFORM=linux
 endif
 SMUDGE_BUILD_DIR=$(shell stack path --local-install-root)
-SMUDGE_RELEASE_DIR=$(SMUDGE_BUILD_DIR)/release
+SMUDGE_RELEASE_DIR=release
+SMUDGE_RELEASE_SUBDIR=smudge
+SMUDGE_RELEASE_STAGE_DIR=$(SMUDGE_RELEASE_DIR)/$(SMUDGE_RELEASE_SUBDIR)
 SMUDGE_TARGET=$(SMUDGE_BUILD_DIR)/bin/$(SMUDGE_EXE)
 
 .PHONY: all tags build examples doc newticket release todo clean distclean
@@ -44,14 +46,16 @@ release: build doc
 	if [ "$$REPLY" = "n" ]; then echo "Well, do that, then!"; exit 1; fi
 	rm -rf $(SMUDGE_RELEASE_DIR) # Make sure it's a clean new release build.
 	mkdir $(SMUDGE_RELEASE_DIR)
-	cp $(SMUDGE_TARGET) $(SMUDGE_RELEASE_DIR)
+	mkdir $(SMUDGE_RELEASE_STAGE_DIR)
+	cp $(SMUDGE_TARGET) $(SMUDGE_RELEASE_STAGE_DIR)
 	$(MAKE) -C docs/tutorial tutorial.pdf
 	$(MAKE) -C docs/tutorial docclean
-	cp -r examples $(SMUDGE_RELEASE_DIR)
-	cp -r docs/tutorial $(SMUDGE_RELEASE_DIR)
-	cp LICENSE $(SMUDGE_RELEASE_DIR)
-	cp README $(SMUDGE_RELEASE_DIR)
-	./tar-up-release.sh $(SMUDGE_BUILD_DIR) $(SMUDGE_RELEASE_DIR) $(SMUDGE_TARGET) $(PLATFORM)
+	cp -r examples $(SMUDGE_RELEASE_STAGE_DIR)
+	cp -r docs/tutorial $(SMUDGE_RELEASE_STAGE_DIR)
+	cp CHANGES $(SMUDGE_RELEASE_STAGE_DIR)
+	cp LICENSE $(SMUDGE_RELEASE_STAGE_DIR)
+	cp README.md $(SMUDGE_RELEASE_STAGE_DIR)
+	./tar-up-release.sh $(SMUDGE_RELEASE_DIR) $(SMUDGE_RELEASE_SUBDIR) $(SMUDGE_TARGET) $(PLATFORM)
 
 todo:
 	@find roadmap/$V | while read -r fn; do find -L tickets/ -xdev -samefile $$fn; done

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ Then, in your shell of choice, run:
 
     $ make
 
-This may take a bit the first time you build, as stack will have to
-download and configure the build environment.
+The first time you build, it might tell you to run
+
+    $ stack setup
+
+This may take a bit, as stack will have to download and configure the
+build environment.
 
 This should work on Windows under Cygwin, as well as reasonably recent
-versions of Debian and Ubuntu. It has worked on other distros and
+versions of Debian (with [issues](https://github.com/commercialhaskell/stack/blob/master/doc/faq.md#i-get-strange-ld-errors-about-recompiling-with--fpic)) and Ubuntu. It has worked on other distros and
 MacOS, and if you have trouble getting it to build we encourage you to
 ask for help on [gitter](https://gitter.im/smudge-sm/Lobby). It
 generates an executable called `smudge` (or `smudge.exe` on Windows) that

--- a/tar-up-release.sh
+++ b/tar-up-release.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 VERSION=`$3 --version | cut -f 3 -d ' ' | head -n 1`
-tar -czf $1/smudge-$VERSION-$4.tgz $2
+cd $1
+tar -czf smudge-$VERSION-$4.tgz $2


### PR DESCRIPTION
Building on Debian has become tricky, and I broke `make release` with
an earlier patch. This fixes that and also puts the release tarball in
a sensible place.